### PR TITLE
Add Git Graph and EVONDev snippets to extension pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
         "WallabyJs.quokka-vscode",
         "MS-vsliveshare.vsliveshare-pack",
         "deerawan.vscode-dash",
-        "jawandarajbir.react-vscode-extension-pack"
+        "jawandarajbir.react-vscode-extension-pack",
+        "evondev.evondev-snippet",
+        "mhutchie.git-graph"
     ]
 }


### PR DESCRIPTION
Added Git Graph extension as well as EVONDEV Snippets which is a handy extension for some HTML setup stuff.  Just quick little snippets to make menus and stuff easier to set up instead of hardcoding it every time.