### PR TITLE
Remove Bracket Pair Colorizer from the extension package

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ One of the things I am always trying to do is find a way to make it easier for o
     -Alphabetical Sorter
     -Axe Accessibility Linter
     -Bookmarks
-    -Bracket Pair Colorizer
     -CSS Peek
     -Debugger for Chrome
     -DotENV

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
         "alefragnani.Bookmarks",
         "baeumer.vscode-eslint",
         "christian-kohler.path-intellisense",
-        "coenraads.bracket-pair-colorizer-2",
         "deerawan.vscode-dash",
         "deque-systems.vscode-axe-linter",
         "eamodio.gitlens",


### PR DESCRIPTION
This is now built into VS Code and is not needed as an extension.
