### PR TITLE
Remove Debugger for Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ One of the things I am always trying to do is find a way to make it easier for o
     -Axe Accessibility Linter
     -Bookmarks
     -CSS Peek
-    -Debugger for Chrome
     -DotENV
     -Drawio
     -ESLint

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
         "mhutchie.git-graph",
         "mikestead.dotenv",
         "MS-vsliveshare.vsliveshare-pack",
-        "msjsdiag.debugger-for-chrome",
         "pranaygp.vscode-css-peek",
         "rangav.vscode-thunder-client",
         "richie5um2.vscode-sort-json",


### PR DESCRIPTION
This is no longer needed. VS Code has this functionality built in as of v1.46.
